### PR TITLE
Fix incorrect content length for head requests

### DIFF
--- a/Sources/OpenAPIVapor/VaporTransport.swift
+++ b/Sources/OpenAPIVapor/VaporTransport.swift
@@ -49,8 +49,12 @@ extension VaporTransport: ServerTransport {
                 from: vaporRequest,
                 forPath: path
             )
-            let response = try await handler(request, body, requestMetadata)
-            return Vapor.Response(response: response.0, body: response.1)
+            let res = try await handler(request, body, requestMetadata)
+            let response = Vapor.Response(response: res.0, body: res.1)
+            if let contentLength = res.0.headerFields.first(where: { $0.name == .contentLength }) {
+                response.headers.replaceOrAdd(name: .contentLength, value: contentLength.value)
+            }
+            return response
         }
     }
 }

--- a/Tests/OpenAPIVaporTests/VaporTransportTests.swift
+++ b/Tests/OpenAPIVaporTests/VaporTransportTests.swift
@@ -28,6 +28,30 @@ final class VaporTransportTests: XCTestCase {
     override func tearDown() async throws {
         app.shutdown()
     }
+    
+    func testHeadRequestExplicitContentLength() async throws {
+        let transport = VaporTransport(routesBuilder: app)
+        let response = HTTPTypes.HTTPResponse(
+            status: .ok,
+            headerFields: [
+                .contentLength: "42"
+            ]
+        )
+        try transport.register(
+            { _, _, _ in (response, nil) },
+            method: .head,
+            path: "/test"
+        )
+        try app.test(
+            .HEAD,
+            "/test",
+            afterResponse: { response in
+                XCTAssertEqual(response.status, .ok)
+                let contentLength = response.headers.first(name: .contentLength)
+                XCTAssertEqual(contentLength, "42")
+            }
+        )
+    }
 
     func testRequestConversion() async throws {
         // POST /hello/{name}


### PR DESCRIPTION
Hello, 

this PR aims to fix the following [issue](https://github.com/vapor/vapor/issues/3084) in the Vapor transport layer service. 

Let me know if you have further feedbacks. 🙏