### PR TITLE
Enable streaming bodies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-runtime.git", .upToNextMinor(from: "0.3.0")),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.84.4"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.86.2"),
         .package(url: "https://github.com/apple/swift-atomics", from: "1.2.0")
     ],
     targets: [

--- a/Sources/OpenAPIVapor/VaporTransport.swift
+++ b/Sources/OpenAPIVapor/VaporTransport.swift
@@ -41,7 +41,8 @@ extension VaporTransport: ServerTransport {
     ) throws {
         self.routesBuilder.on(
             HTTPMethod(method),
-            [PathComponent](path)
+            [PathComponent](path),
+            body: .stream
         ) { vaporRequest in
             let request = try HTTPTypes.HTTPRequest(vaporRequest)
             let body = OpenAPIRuntime.HTTPBody(vaporRequest)


### PR DESCRIPTION
This PR will enable streaming bodies instead of buffering them.

- [x] Locally tested
- [x] Test with OpenAPI generator's Vapor example